### PR TITLE
Trigger onchange event after updating

### DIFF
--- a/src/momentpicker.coffee
+++ b/src/momentpicker.coffee
@@ -77,7 +77,7 @@ class MomentPicker extends SimpleModule
       else if d.type == 'time'
         @moment.set('hour', d.moment.hour())
         @moment.set('minute', d.moment.minute())
-      @el.val(@moment.format(@_inputValueFormat))
+      @el.val(@moment.format(@_inputValueFormat)).change()
 
   getMoment: ->
     @moment.clone()


### PR DESCRIPTION
Currently when an input is updated, an onchange event is not triggered. Without this, we cannot attach an onchange handler for inputs.
